### PR TITLE
OP-1725: remove null/empty options from dropdowns

### DIFF
--- a/src/components/Uploader.js
+++ b/src/components/Uploader.js
@@ -52,7 +52,7 @@ const Uploader = ({
                   }
                   required
                   constants={acceptableFormats}
-                  withNull
+                  withNull={false}
                 />
                 <Grid item>
                   <Button
@@ -105,7 +105,7 @@ const Uploader = ({
                     }
                     required
                     constants={strategies}
-                    withNull
+                    withNull={false}
                   />
                 </Grid>
                 <Grid item>

--- a/src/pages/RegistersPage.js
+++ b/src/pages/RegistersPage.js
@@ -358,7 +358,7 @@ const RegistersPage = () => {
                             }
                             required
                             constants={DIAGNOSES_STRATEGIES}
-                            withNull
+                            withNull={false}
                           />
                         </Grid>
                         <Grid item>
@@ -492,7 +492,7 @@ const RegistersPage = () => {
                             }
                             required
                             constants={LOCATIONS_STRATEGIES}
-                            withNull
+                            withNull={false}
                           />
                         </Grid>
                         <Grid item>
@@ -626,7 +626,7 @@ const RegistersPage = () => {
                             }
                             required
                             constants={HEALTH_FACILITIES_STRATEGIES}
-                            withNull
+                            withNull={false}
                           />
                         </Grid>
                         <Grid item>
@@ -746,7 +746,7 @@ const RegistersPage = () => {
                           }
                           required
                           constants={EXPORT_TYPES}
-                          withNull
+                          withNull={false}
                         />
                         <Grid item>
                           <Button
@@ -803,7 +803,7 @@ const RegistersPage = () => {
                             }
                             required
                             constants={MEDICAL_ITEMS_STRATEGIES}
-                            withNull
+                            withNull={false}
                           />
                         </Grid>
                         <Grid item>
@@ -896,7 +896,7 @@ const RegistersPage = () => {
                           }
                           required
                           constants={EXPORT_TYPES}
-                          withNull
+                          withNull={false}
                         />
                         <Grid item>
                           <Button
@@ -957,7 +957,7 @@ const RegistersPage = () => {
                             }
                             required
                             constants={MEDICAL_SERVICES_STRATEGIES}
-                            withNull
+                            withNull={false}
                           />
                         </Grid>
                         <Grid item>


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ